### PR TITLE
Update and Fixed Use of a Broken or Risky Cryptographic Algorithm

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -66,7 +66,7 @@
         "typescript": "^4.0.2"
       },
       "engines": {
-        "node": "14.x"
+        "node": ">=14"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -6955,9 +6955,9 @@
       }
     },
     "node_modules/crypto-js": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.1.1.tgz",
-      "integrity": "sha512-o2JlM7ydqd3Qk9CA0L4NL6mTzU2sdx96a+oOfPu8Mkl/PK51vSyoi8/rQ8NknZtk44vq15lmhAj9CIAGwgeWKw=="
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.2.0.tgz",
+      "integrity": "sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q=="
     },
     "node_modules/css-select": {
       "version": "5.1.0",
@@ -24706,9 +24706,9 @@
       }
     },
     "crypto-js": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.1.1.tgz",
-      "integrity": "sha512-o2JlM7ydqd3Qk9CA0L4NL6mTzU2sdx96a+oOfPu8Mkl/PK51vSyoi8/rQ8NknZtk44vq15lmhAj9CIAGwgeWKw=="
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.2.0.tgz",
+      "integrity": "sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q=="
     },
     "css-select": {
       "version": "5.1.0",


### PR DESCRIPTION
## Description
 `yamatoprotocol/core` js PBKDF2 1,000 times weaker than specified in 1993 and 1.3M times weaker than current standard
Affected of this project `yamatoprotocol/core` are vulnerable to Use of Weak Hash due to inadequate security settings in the PBKDF2 configuration, which uses insecure SHA1 and has a low iteration count of 1. These insecure settings allow attackers to perform brute-force attacks when PBKDF2 is used with the default parameters.

No information is directly exposed when a hash is generated, regardless of whether the PBKDF2 function is in the vulnerable configuration or not. However, it may be possible to recover the original data, more or less easily depending on the configured parameters, using a brute force attack. This is a low impact on the confidentiality of the protected data, which are in a different scope than the vulnerable package.

The attacker similarly may be able to modify some data which is meant to be protected by the vulnerable package - most commonly when it is used for signature verification. This would require a subsequent exploitation, such as forcing a hash collision via length extension attack. The integrity of the data is therefore compromised, but the quantity and targeting of that data is not fully in the attacker's control, yielding a low integrity impact.

To encrypt the user password via symmetric encryption we might do encrypt(plaintext: 'fake-password', encryption_key: cryptojs.pbkdf2(value: 'example username' + salt_or_pepper)). By this means, we would, in theory, create an encryption_key that can be determined from the public username, but which requires the secret salt_or_pepper to generate. This is a common scheme for protecting passwords, as exemplified in bcrypt & scrypt. Because the encryption key is symmetric, we can use this derived key to also decrypt the ciphertext.

```js
    var PBKDF2 = C_algo.PBKDF2 = Base.extend({
        /**
         * Configuration options.
         *
         * @property {number} keySize The key size in words to generate. Default: 4 (128 bits)
         * @property {Hasher} hasher The hasher to use. Default: SHA1
         * @property {number} iterations The number of iterations to perform. Default: 1
         */
        cfg: Base.extend({
            keySize: 128/32,
            hasher: SHA1,
            iterations: 1
        }),
```
CVE-2023-46233
CWE-327
CWE-328
CWE-916
`CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:N`